### PR TITLE
Add polyfills for Buffer and global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@rainbow-me/rainbowkit": "^0.4.1",
+        "buffer": "^6.0.3",
         "ethers": "^5.6.9",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^0.4.1",
+    "buffer": "^6.0.3",
     "ethers": "^5.6.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "./polyfills";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "buffer";
+
+window.global = window.global ?? window;
+window.Buffer = window.Buffer ?? Buffer;
+
+export {};


### PR DESCRIPTION
Vite isn't providing the polyfills that some dependencies are expecting. This PR adds `window.global` and `window.Buffer` so that everything works as expected.